### PR TITLE
Fix bug that messes up part of summary creation in GraphInterface

### DIFF
--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -112,7 +112,8 @@ class GraphInterface:
                         labels = labels if isinstance(labels, list) else[labels]
                         count = node['count']
                         query = f"""
-                        MATCH (:{':'.join(labels)})-[e]->(b) WITH DISTINCT e , b 
+                        MATCH (n)-[e]->(b) WITH DISTINCT e , b
+                        WHERE labels(n) in {labels}
                         RETURN 
                             type(e) as edge_types, 
                             count(e) as edge_counts,


### PR DESCRIPTION
Fixes a bug in a Cypher query in `get_schema` related to constructing the `summary` field in `GraphInterface`. Before, `self.summary` would never contain edge data because this query was broken.