### PR TITLE
Redis connection fix

### DIFF
--- a/PLATER/openapi-config.yaml
+++ b/PLATER/openapi-config.yaml
@@ -13,4 +13,4 @@ description: "" # Description for the whole spec
 title: "" # title for the whole spec, overrides PLATER_TITLE env value
 servers:
   - description: Default server
-    url: http://localhost:8080 # full url not this will be the url used when using openapi docs
+    url: http://localhost:8080 # full url not this will be the url used when using openapi doc

--- a/PLATER/openapi-config.yaml
+++ b/PLATER/openapi-config.yaml
@@ -13,4 +13,4 @@ description: "" # Description for the whole spec
 title: "" # title for the whole spec, overrides PLATER_TITLE env value
 servers:
   - description: Default server
-    url: http://localhost:9000 # full url not this will be the url used when using openapi docs
+    url: http://localhost:8080 # full url not this will be the url used when using openapi docs

--- a/PLATER/openapi-config.yaml
+++ b/PLATER/openapi-config.yaml
@@ -13,4 +13,4 @@ description: "" # Description for the whole spec
 title: "" # title for the whole spec, overrides PLATER_TITLE env value
 servers:
   - description: Default server
-    url: http://localhost:8080 # full url not this will be the url used when using openapi docs
+    url: http://localhost:9000 # full url not this will be the url used when using openapi docs

--- a/PLATER/openapi-config.yaml
+++ b/PLATER/openapi-config.yaml
@@ -13,4 +13,4 @@ description: "" # Description for the whole spec
 title: "" # title for the whole spec, overrides PLATER_TITLE env value
 servers:
   - description: Default server
-    url: http://localhost:8080 # full url not this will be the url used when using openapi doc
+    url: http://localhost:8080 # full url not this will be the url used when using openapi docs

--- a/PLATER/requirements.txt
+++ b/PLATER/requirements.txt
@@ -5,9 +5,8 @@ pytest-asyncio==0.14.0
 starlette==0.13.6
 uvicorn==0.11.7
 httpx
-redis
+redis==4.1.2
 reasoner-transpiler==1.7.1
 bmt==0.7.3
 git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.1.2.1#egg=reasoner-pydantic
 git+https://github.com/patrickkwang/fastapi#egg=fastapi
-git+https://github.com/redislabs/redisgraph-py.git

--- a/PLATER/services/util/drivers/redis_driver.py
+++ b/PLATER/services/util/drivers/redis_driver.py
@@ -23,6 +23,7 @@ class RedisDriver:
                                              password=password,
                                              retry_on_error=[ConnectionError],
                                              retry=Retry(backoff=NoBackoff(), retries=3),
+                                             health_check_interval=2,
                                              encoding='utf-8',
                                              decode_responses=True)
         self.graph_name = graph_db_name

--- a/PLATER/services/util/drivers/redis_trapi_cypher_compiler.py
+++ b/PLATER/services/util/drivers/redis_trapi_cypher_compiler.py
@@ -60,7 +60,7 @@ class NodeReference():
 
         self.name = name
         self.labels = labels
-        self.prop_string = ' {' + ', '.join([f"`{key}`: {cypher_prop_string(props[key])}" for key in props]) + '}'
+        self.prop_string = ' {' + ', '.join([f"`{key}`: {cypher_prop_string(props[key])}" for key in props if props[key]]) + '}'
         if curie:
             # redis graph doesnt support USING INDEX version 2.4.2
             self._extras = '' #f' USING INDEX {name}:`{labels[0]}`(id)'


### PR DESCRIPTION
- Upgrade to latest redis lib 4.1.2
- Removes deprecated redisgraph-py (https://github.com/RedisGraph/redisgraph-py/pull/160) 
- Adds retry and health check for redis connection class